### PR TITLE
Normalize when child components are created

### DIFF
--- a/apis/aliases.go
+++ b/apis/aliases.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"reconciler.io/runtime/apis"
+)
+
+var (
+	ConditionIsFalse   = apis.ConditionIsFalse
+	ConditionIsTrue    = apis.ConditionIsTrue
+	ConditionIsUnknown = apis.ConditionIsUnknown
+)

--- a/apis/annotations.go
+++ b/apis/annotations.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+const (
+	CreateChildComponentAnnotation = "wa8s.reconciler.io/create-child-component"
+	CreateChildComponentTrue       = "true"
+	CreateChildComponentFalse      = "false"
+	CreateChildComponentAuto       = "auto"
+)
+
+func ValidateCommonAnnotations(ctx context.Context, fldPath *field.Path, resource runtime.Object) field.ErrorList {
+	errs := field.ErrorList{}
+
+	annotations := resource.(metav1.Object).GetAnnotations()
+	if annotations == nil {
+		return errs
+	}
+
+	if createChild, ok := annotations[CreateChildComponentAnnotation]; ok {
+		if createChild != CreateChildComponentTrue && createChild != CreateChildComponentFalse && createChild != CreateChildComponentAuto {
+			errs = append(errs, field.Invalid(
+				fldPath.Child("metadata", "annotations", CreateChildComponentAnnotation), createChild,
+				fmt.Sprintf("must be one of: %s, %s, %s", CreateChildComponentTrue, CreateChildComponentFalse, CreateChildComponentAnnotation)),
+			)
+		}
+	}
+
+	return errs
+}

--- a/apis/components/v1alpha1/component_webhook.go
+++ b/apis/components/v1alpha1/component_webhook.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/internal/defaults"
 	"reconciler.io/wa8s/validation"
 )
@@ -149,6 +150,7 @@ func (r *Component) ValidateDelete(ctx context.Context, obj runtime.Object) (war
 func (r *Component) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs
@@ -181,6 +183,7 @@ func (r *ClusterComponent) ValidateDelete(ctx context.Context, obj runtime.Objec
 func (r *ClusterComponent) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/components/v1alpha1/composition_webhook.go
+++ b/apis/components/v1alpha1/composition_webhook.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/json"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -156,6 +157,7 @@ func (r *Composition) validateNoUnknownFields(ctx context.Context) error {
 func (r *Composition) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/components/v1alpha1/configstore_webhook.go
+++ b/apis/components/v1alpha1/configstore_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -132,6 +133,7 @@ func (r *ConfigStore) ValidateDelete(ctx context.Context, obj runtime.Object) (w
 func (r *ConfigStore) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/containers/v1alpha1/crontrigger_webhook.go
+++ b/apis/containers/v1alpha1/crontrigger_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -88,6 +89,7 @@ func (r *CronTrigger) ValidateDelete(ctx context.Context, obj runtime.Object) (w
 func (r *CronTrigger) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/containers/v1alpha1/httptrigger_webhook.go
+++ b/apis/containers/v1alpha1/httptrigger_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -88,6 +89,7 @@ func (r *HttpTrigger) ValidateDelete(ctx context.Context, obj runtime.Object) (w
 func (r *HttpTrigger) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/containers/v1alpha1/wasmtimecontainer_webhook.go
+++ b/apis/containers/v1alpha1/wasmtimecontainer_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -99,6 +100,7 @@ func (r *WasmtimeContainer) ValidateDelete(ctx context.Context, obj runtime.Obje
 func (r *WasmtimeContainer) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/containers/v1alpha1/wrpctrigger_webhook.go
+++ b/apis/containers/v1alpha1/wrpctrigger_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -88,6 +89,7 @@ func (r *WrpcTrigger) ValidateDelete(ctx context.Context, obj runtime.Object) (w
 func (r *WrpcTrigger) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/registries/v1alpha1/repository_webhook.go
+++ b/apis/registries/v1alpha1/repository_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/internal/defaults"
 	"reconciler.io/wa8s/validation"
 )
@@ -160,6 +161,7 @@ func (r *Repository) ValidateDelete(ctx context.Context, obj runtime.Object) (wa
 func (r *Repository) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs
@@ -192,6 +194,7 @@ func (r *ClusterRepository) ValidateDelete(ctx context.Context, obj runtime.Obje
 func (r *ClusterRepository) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/services/v1alpha1/servicebinding_lifecycle.go
+++ b/apis/services/v1alpha1/servicebinding_lifecycle.go
@@ -23,11 +23,12 @@ import (
 )
 
 const (
-	ServiceBindingConditionReady         = apis.ConditionReady
-	ServiceBindingConditionInstanceReady = "InstanceReady"
-	ServiceBindingConditionSecret        = "Secret"
-	ServiceBindingConditionBound         = "Bound"
-	ServiceBindingConditionClientReady   = "ClientReady"
+	ServiceBindingConditionReady          = apis.ConditionReady
+	ServiceBindingConditionInstanceReady  = "InstanceReady"
+	ServiceBindingConditionSecret         = "Secret"
+	ServiceBindingConditionBound          = "Bound"
+	ServiceBindingConditionClientReady    = "ClientReady"
+	ServiceBindingConditionChildComponent = "ChildComponent"
 )
 
 func (s *ServiceBinding) GetConditionsAccessor() apis.ConditionsAccessor {
@@ -45,6 +46,7 @@ func (s *ServiceBindingStatus) GetConditionSet() apis.ConditionSet {
 		ServiceBindingConditionSecret,
 		ServiceBindingConditionBound,
 		ServiceBindingConditionClientReady,
+		ServiceBindingConditionChildComponent,
 	)
 }
 

--- a/apis/services/v1alpha1/servicebinding_webhook.go
+++ b/apis/services/v1alpha1/servicebinding_webhook.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -103,6 +104,7 @@ func (r *ServiceBinding) ValidateDelete(ctx context.Context, obj runtime.Object)
 func (r *ServiceBinding) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/services/v1alpha1/serviceclient_lifecycle.go
+++ b/apis/services/v1alpha1/serviceclient_lifecycle.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	ServiceClientConditionReady = apis.ConditionReady
-	ServiceClientConditionBound = "Bound"
+	ServiceClientConditionReady          = apis.ConditionReady
+	ServiceClientConditionBound          = "Bound"
+	ServiceClientConditionChildComponent = "ChildComponent"
 )
 
 func (s *ServiceClient) GetConditionsAccessor() apis.ConditionsAccessor {
@@ -39,6 +40,7 @@ func (s *ServiceClientStatus) GetConditionSet() apis.ConditionSet {
 	return apis.NewLivingConditionSetWithHappyReason(
 		"Ready",
 		ServiceClientConditionBound,
+		ServiceClientConditionChildComponent,
 	)
 }
 

--- a/apis/services/v1alpha1/serviceclient_webhook.go
+++ b/apis/services/v1alpha1/serviceclient_webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -109,6 +110,7 @@ func (r *ServiceClient) ValidateDelete(ctx context.Context, obj runtime.Object) 
 func (r *ServiceClient) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/services/v1alpha1/serviceclientduck_lifecycle.go
+++ b/apis/services/v1alpha1/serviceclientduck_lifecycle.go
@@ -25,6 +25,7 @@ import (
 const (
 	ServiceClientDuckConditionReady              = apis.ConditionReady
 	ServiceClientDuckConditionServiceClientReady = "ServiceClientReady"
+	ServiceClientDuckConditionChildComponent     = "ChildComponent"
 )
 
 func (s *ServiceClientDuck) GetConditionsAccessor() apis.ConditionsAccessor {
@@ -39,6 +40,7 @@ func (s *ServiceClientDuckStatus) GetConditionSet() apis.ConditionSet {
 	return apis.NewLivingConditionSetWithHappyReason(
 		"Ready",
 		ServiceClientDuckConditionServiceClientReady,
+		ServiceClientDuckConditionChildComponent,
 	)
 }
 

--- a/apis/services/v1alpha1/serviceinstance_webhook.go
+++ b/apis/services/v1alpha1/serviceinstance_webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -127,6 +128,7 @@ func (r *ServiceInstance) ValidateDelete(ctx context.Context, obj runtime.Object
 func (r *ServiceInstance) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/services/v1alpha1/servicelifecycle_webhook.go
+++ b/apis/services/v1alpha1/servicelifecycle_webhook.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -146,6 +147,7 @@ func (r *ServiceLifecycle) ValidateDelete(ctx context.Context, obj runtime.Objec
 func (r *ServiceLifecycle) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs
@@ -178,6 +180,7 @@ func (r *ClusterServiceLifecycle) ValidateDelete(ctx context.Context, obj runtim
 func (r *ClusterServiceLifecycle) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/apis/services/v1alpha1/serviceresourcedefinition_webhook.go
+++ b/apis/services/v1alpha1/serviceresourcedefinition_webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"reconciler.io/wa8s/apis"
 	"reconciler.io/wa8s/validation"
 )
 
@@ -108,6 +109,7 @@ func (r *ServiceResourceDefinition) ValidateDelete(ctx context.Context, obj runt
 func (r *ServiceResourceDefinition) Validate(ctx context.Context, fldPath *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
+	errs = append(errs, apis.ValidateCommonAnnotations(ctx, fldPath, r)...)
 	errs = append(errs, r.Spec.Validate(ctx, fldPath.Child("spec"))...)
 
 	return errs

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -43,6 +43,8 @@ import (
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 
 func ServiceBindingReconciler(c reconcilers.Config) *reconcilers.ResourceReconciler[*servicesv1alpha1.ServiceBinding] {
+	childLabelKey := fmt.Sprintf("%s/service-binding", servicesv1alpha1.GroupVersion.Group)
+
 	return &reconcilers.ResourceReconciler[*servicesv1alpha1.ServiceBinding]{
 		Reconciler: &reconcilers.WithFinalizer[*servicesv1alpha1.ServiceBinding]{
 			Finalizer: fmt.Sprintf("%s/reconciler", servicesv1alpha1.GroupVersion.Group),
@@ -53,6 +55,7 @@ func ServiceBindingReconciler(c reconcilers.Config) *reconcilers.ResourceReconci
 					ManageServiceBinding(),
 					ConfigureClientComponent(),
 					ExpirationRequeue(),
+					ComponentChildReconciler[*servicesv1alpha1.ServiceBinding](servicesv1alpha1.ServiceBindingConditionChildComponent, childLabelKey, nil),
 				},
 			},
 		},

--- a/controllers/serviceclient_controller.go
+++ b/controllers/serviceclient_controller.go
@@ -39,11 +39,14 @@ import (
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 
 func ServiceClientReconciler(c reconcilers.Config) *reconcilers.ResourceReconciler[*servicesv1alpha1.ServiceClient] {
+	childLabelKey := fmt.Sprintf("%s/service-client", servicesv1alpha1.GroupVersion.Group)
+
 	return &reconcilers.ResourceReconciler[*servicesv1alpha1.ServiceClient]{
 		Reconciler: &reconcilers.SuppressTransientErrors[*servicesv1alpha1.ServiceClient, *servicesv1alpha1.ServiceClientList]{
 			Reconciler: reconcilers.Sequence[*servicesv1alpha1.ServiceClient]{
 				StampServiceBinding(),
 				RenewRequeue(),
+				ComponentChildReconciler[*servicesv1alpha1.ServiceClient](servicesv1alpha1.ServiceClientConditionChildComponent, childLabelKey, nil),
 			},
 		},
 

--- a/examples/valkey-service/03-service-client.yaml
+++ b/examples/valkey-service/03-service-client.yaml
@@ -9,6 +9,5 @@ spec:
   scopes:
   - read
   - write
-  # last 1h while rotating every 5m for demos
   duration: 1h
-  renewBefore: 55m
+  renewBefore: 15m

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20250115185438-c4dd792fa06c
+	github.com/stoewer/go-strcase v1.3.0
 	github.com/tetratelabs/wazero v1.9.0
 	k8s.io/api v0.33.0
 	k8s.io/apiextensions-apiserver v0.33.0
@@ -104,7 +105,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
 	github.com/vbatts/tar-split v0.11.6 // indirect
 	github.com/x448/float16 v0.8.4 // indirect


### PR DESCRIPTION
All ComponentLike resources will now create a child Component resource with the same name by default when the parent resource is not owned. An annotation `wa8s.recocniler.io/create-child-component` can override the default behavior with values `true`, `false`, or `auto`.