### PR TITLE
Use cloud-provider-kind to simplify ingress

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,14 +265,13 @@ jobs:
       id: registry
       uses: reconcilerio/registry@v1
     - name: kind cluster
-      uses: reconcilerio/kind@v1
+      # uses: reconcilerio/kind@v1
+      uses: scothis/kind@cloud-provider-kind
       with:
         kubernetes-version: ${{ matrix.kubernetes }}
+        cloud-provider-kind-version: auto
         registry: ${{ steps.registry.outputs.registry }}
         registry-ca: ${{ steps.registry.outputs.tls-ca }}
-    - name: cloud-provider-kind
-      # uses: reconcilerio/kind/cloud-provider-kind@v1
-      uses: scothis/kind/cloud-provider-kind@cloud-provider-kind
     - name: Download staged bundle
       uses: actions/download-artifact@v8
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -414,8 +414,6 @@ jobs:
             echo "Unexpected /greeting count: got ${count}, wanted 2"
             exit 1
           fi
-
-          kill ${kpf_pid}
         echo "##[endgroup]"
 
     - name: Collect diagnostics

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,6 +270,8 @@ jobs:
         kubernetes-version: ${{ matrix.kubernetes }}
         registry: ${{ steps.registry.outputs.registry }}
         registry-ca: ${{ steps.registry.outputs.tls-ca }}
+    - name: cloud-provider-kind
+      uses: reconcilerio/kind/cloud-provider-kind@v1
     - name: Download staged bundle
       uses: actions/download-artifact@v8
       with:
@@ -304,10 +306,10 @@ jobs:
           ${KAPP} deploy -a knative-serving -n apps --wait-timeout 5m -y \
             -f <( \
               ${YTT} \
-                --data-value service-type=ClusterIP \
+			          --data-value external-domain=knative.local \
                 --data-value ingress-class=kourier.ingress.networking.knative.dev \
+			          -f config/overlays/knative-domain.yaml \
                 -f config/overlays/knative-ingress-class.yaml \
-                -f config/overlays/knative-no-loadbalancer.yaml \
                 -f https://github.com/knative/serving/releases/download/knative-v1.21.2/serving-crds.yaml \
                 -f https://github.com/knative/serving/releases/download/knative-v1.21.2/serving-core.yaml \
                 -f https://github.com/knative-extensions/net-kourier/releases/download/knative-v1.21.0/kourier.yaml \
@@ -377,13 +379,10 @@ jobs:
         echo "##[endgroup]"
 
         echo "##[group]invoke incrementor"
-          kubectl port-forward -n kourier-system svc/kourier-internal 8080:80 &
-          kpf_pid=$!
-          while ! nc -z localhost 8080 </dev/null; do sleep 1; done
+          ingress_ip=$(kubectl get svc -n kourier-system kourier -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          incrementor_host=$(kubectl get servicetriggers.knative.wa8s.reconciler.io incrementor -o=jsonpath='{.status.url}'| cut -d'/' -f3)
 
-          host="incrementor.default.svc.cluster.local"
-
-          count=$(curl -s -H "Host: ${host}" http://localhost:8080/hello)
+          count=$(curl -s -H "Host: ${incrementor_host}" http://${ingress_ip}/hello)
           if [ "${count}" == "1" ]; then
             echo "/hello count: ${count}"
           else
@@ -391,7 +390,7 @@ jobs:
             exit 1
           fi
 
-          count=$(curl -s -H "Host: ${host}" http://localhost:8080/greeting)
+          count=$(curl -s -H "Host: ${incrementor_host}" http://${ingress_ip}/greeting)
           if [ "${count}" == "1" ]; then
             echo "/greeting count: ${count}"
           else
@@ -399,7 +398,7 @@ jobs:
             exit 1
           fi
 
-          count=$(curl -s -H "Host: ${host}" http://localhost:8080/hello)
+          count=$(curl -s -H "Host: ${incrementor_host}" http://${ingress_ip}/hello)
           if [ "${count}" == "2" ]; then
             echo "/hello count: ${count}"
           else
@@ -407,7 +406,7 @@ jobs:
             exit 1
           fi
 
-          count=$(curl -s -H "Host: ${host}" http://localhost:8080/greeting)
+          count=$(curl -s -H "Host: ${incrementor_host}" http://${ingress_ip}/greeting)
           if [ "${count}" == "2" ]; then
             echo "/greeting count: ${count}"
           else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -307,9 +307,9 @@ jobs:
           ${KAPP} deploy -a knative-serving -n apps --wait-timeout 5m -y \
             -f <( \
               ${YTT} \
-			          --data-value external-domain=knative.local \
+                --data-value external-domain=knative.local \
                 --data-value ingress-class=kourier.ingress.networking.knative.dev \
-			          -f config/overlays/knative-domain.yaml \
+                -f config/overlays/knative-domain.yaml \
                 -f config/overlays/knative-ingress-class.yaml \
                 -f https://github.com/knative/serving/releases/download/knative-v1.21.2/serving-crds.yaml \
                 -f https://github.com/knative/serving/releases/download/knative-v1.21.2/serving-core.yaml \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -271,7 +271,8 @@ jobs:
         registry: ${{ steps.registry.outputs.registry }}
         registry-ca: ${{ steps.registry.outputs.tls-ca }}
     - name: cloud-provider-kind
-      uses: reconcilerio/kind/cloud-provider-kind@v1
+      # uses: reconcilerio/kind/cloud-provider-kind@v1
+      uses: scothis/kind/cloud-provider-kind@cloud-provider-kind
     - name: Download staged bundle
       uses: actions/download-artifact@v8
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,8 +265,7 @@ jobs:
       id: registry
       uses: reconcilerio/registry@v1
     - name: kind cluster
-      # uses: reconcilerio/kind@v1
-      uses: scothis/kind@cloud-provider-kind
+      uses: reconcilerio/kind@v1
       with:
         kubernetes-version: ${{ matrix.kubernetes }}
         cloud-provider-kind-version: auto

--- a/Makefile
+++ b/Makefile
@@ -150,10 +150,10 @@ undeploy-ducks: ## Undeploy cert-manager from the K8s cluster specified in ~/.ku
 deploy-knative-serving: ## Deploy knative serving to the K8s cluster specified in ~/.kube/config.
 	$(KAPP) deploy -a knative-serving -n $(KAPP_APP_NAMESPACE) --wait-timeout 5m -c $(KAPP_OPTS) \
 		-f <($(YTT) \
-			--data-value service-type=ClusterIP \
+			--data-value external-domain=knative.local \
 			--data-value ingress-class=kourier.ingress.networking.knative.dev \
+			-f config/overlays/knative-domain.yaml \
 			-f config/overlays/knative-ingress-class.yaml \
-			-f config/overlays/knative-no-loadbalancer.yaml \
 			-f https://github.com/knative/serving/releases/download/knative-v1.21.2/serving-crds.yaml \
 			-f https://github.com/knative/serving/releases/download/knative-v1.21.2/serving-core.yaml \
 			-f https://github.com/knative-extensions/net-kourier/releases/download/knative-v1.21.0/kourier.yaml \

--- a/config/overlays/knative-domain.yaml
+++ b/config/overlays/knative-domain.yaml
@@ -1,0 +1,9 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"apiVersion":"v1","kind":"ConfigMap","metadata":{"namespace":"knative-serving","name":"config-domain"}})
+---
+#@yaml/text-templated-strings
+data:
+  #@overlay/match missing_ok=True
+  (@= data.values['external-domain'] @): |

--- a/config/overlays/knative-no-loadbalancer.yaml
+++ b/config/overlays/knative-no-loadbalancer.yaml
@@ -1,7 +1,0 @@
-#@ load("@ytt:data", "data")
-#@ load("@ytt:overlay", "overlay")
-
-#@overlay/match expects='1+', by=overlay.subset({"apiVersion":"v1","kind":"Service","spec":{"type":"LoadBalancer"}})
----
-spec:
-  type: #@ data.values['service-type']


### PR DESCRIPTION
cloud-provider-kind satisfies LoadBalancer services by binding to IPs on the docker network that are accessible to the host and forwards traffic into the cluster. It is no longer necessary to port-forward.